### PR TITLE
[Bug] fix bug in truncated folder name when name is longer than 40 chars

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,6 +168,8 @@ data:
 
 
 ## Changelog
+- v1.3.2
+  - Fix folder name to not get truncated when name is longer than 40 characters.
 - v1.3.1
   - Enforce a 40-character limit on the auto-generated Grafana folder UIDs to prevent runtime exceptions when the generated UID is too long.
 - v1.3.0

--- a/logzio_alerts_client/logzio_alerts_client.go
+++ b/logzio_alerts_client/logzio_alerts_client.go
@@ -530,11 +530,9 @@ func (l *LogzioGrafanaAlertsClient) FindOrCreatePrometheusAlertsFolder() (string
 // generateGrafanaFolder creates a Grafana folder with a unique UID based on the provided title.
 func (l *LogzioGrafanaAlertsClient) generateGrafanaFolder(folderTitle string) (*grafanafolders.GrafanaFolder, error) {
 	maxTitleNameInId := maxFolderNameLength - (randomStringLength + 1) // +1 for the hyphen
-	var uidPrefix string
+	uidPrefix := folderTitle
 	if len(folderTitle) > maxTitleNameInId {
 		uidPrefix = folderTitle[:maxTitleNameInId]
-	} else {
-		uidPrefix = folderTitle
 	}
 	uid := fmt.Sprintf("%s-%s", uidPrefix, common.GenerateRandomString(randomStringLength))
 

--- a/logzio_alerts_client/logzio_alerts_client.go
+++ b/logzio_alerts_client/logzio_alerts_client.go
@@ -520,25 +520,32 @@ func (l *LogzioGrafanaAlertsClient) FindOrCreatePrometheusAlertsFolder() (string
 		}
 	}
 	// if not found, create the prometheus alerts folder
-	return l.generateGrafanaFolder(envFolderTitle)
+	newFolder, err := l.generateGrafanaFolder(envFolderTitle)
+	if err != nil {
+		return "", err
+	}
+	return newFolder.Uid, nil
 }
 
 // generateGrafanaFolder creates a Grafana folder with a unique UID based on the provided title.
-func (l *LogzioGrafanaAlertsClient) generateGrafanaFolder(folderTitle string) (string, error) {
+func (l *LogzioGrafanaAlertsClient) generateGrafanaFolder(folderTitle string) (*grafanafolders.GrafanaFolder, error) {
 	maxTitleNameInId := maxFolderNameLength - (randomStringLength + 1) // +1 for the hyphen
+	var uidPrefix string
 	if len(folderTitle) > maxTitleNameInId {
-		folderTitle = folderTitle[:maxTitleNameInId]
+		uidPrefix = folderTitle[:maxTitleNameInId]
+	} else {
+		uidPrefix = folderTitle
 	}
-	uid := fmt.Sprintf("%s-%s", folderTitle, common.GenerateRandomString(randomStringLength))
+	uid := fmt.Sprintf("%s-%s", uidPrefix, common.GenerateRandomString(randomStringLength))
 
 	grafanaFolder, err := l.logzioFolderClient.CreateGrafanaFolder(grafanafolders.CreateUpdateFolder{
 		Uid:   uid,
 		Title: folderTitle,
 	})
 	if err != nil {
-		return "", err
+		return nil, err
 	}
-	return grafanaFolder.Uid, nil
+	return grafanaFolder, nil
 }
 
 // DeleteFolders deletes the specified folders by their UIDs.

--- a/logzio_alerts_client/logzio_alerts_client_test.go
+++ b/logzio_alerts_client/logzio_alerts_client_test.go
@@ -215,16 +215,17 @@ func TestGenerateGrafanaFolder(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			folderUid, err := client.generateGrafanaFolder(tc.folderName)
+			newFolder, err := client.generateGrafanaFolder(tc.folderName)
 			if tc.expectedError != nil {
 				assert.Error(t, err, "Expected error but got none")
 				assert.EqualError(t, err, tc.expectedError.Error(), "Unexpected error message")
 				return
 			} else {
 				assert.NoError(t, err, "Unexpected error generating grafana folder: %v", err)
-				assert.Len(t, folderUid, tc.expectedLength, "Folder UID length mismatch, expected %d, got %v", tc.expectedLength, folderUid)
-				assert.True(t, strings.HasPrefix(folderUid, tc.expectedUidPrefix), "Incorrect folder name, expected prefix %s, got %s", tc.expectedUidPrefix, folderUid)
-				client.DeleteFolders([]string{folderUid})
+				assert.Len(t, newFolder.Uid, tc.expectedLength, "Folder UID length mismatch, expected %d, got %v", tc.expectedLength, newFolder.Uid)
+				assert.True(t, strings.HasPrefix(newFolder.Uid, tc.expectedUidPrefix), "Incorrect folder uid, expected prefix %s, got %s", tc.expectedUidPrefix, newFolder.Uid)
+				assert.Equal(t, newFolder.Title, tc.folderName, "Folder name should match the used test case name")
+				client.DeleteFolders([]string{newFolder.Uid})
 			}
 		})
 	}


### PR DESCRIPTION
## Description 

following the last version, truncating the folder name in the UID to prevent the UID from being too long, noticed bug that we also truncate the original folder name. This PR solves the issue to keep the original folder name and only truncate it in the part we add to the UID.

## What type of PR is this?
#### (check all applicable)
- [ ] 🍕 Feature 
- [x] 🐛 Bug Fix
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build / CI
- [ ] ⏩ Revert

## Added tests?

- [x] 👍 yes
- [ ] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help from somebody
